### PR TITLE
Data disk support for Cloudstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Very condensed HOWTO, more to follow:
 * pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/master.zip
 * pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/master.zip
 * pip install https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/master.zip
-*pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/master.zip
+* pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/master.zip
 * git clone https://github.com/schubergphilis/cloudify-manager-blueprints.git
 * git clone https://github.com/schubergphilis/cloudify-nodecellar-example.git
 * cp cloudify-manager-blueprints/cloudstack/inputs.json.template cloudify-config.json

--- a/cloudstack_plugin/volume.py
+++ b/cloudstack_plugin/volume.py
@@ -1,0 +1,54 @@
+########
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+
+
+from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError
+
+from cloudstack_plugin.cloudstack_common import (
+    get_cloud_driver,
+    get_resource_id,
+    CLOUDSTACK_ID_PROPERTY,
+    CLOUDSTACK_NAME_PROPERTY,
+    CLOUDSTACK_TYPE_PROPERTY,
+    COMMON_RUNTIME_PROPERTIES_KEYS
+
+)
+from cloudstack_plugin.virtual_machine import get_vm_by_id
+
+VOLUME_CLOUDSTACK_TYPE = 'volume'
+
+RUNTIME_PROPERTIES_KEYS = COMMON_RUNTIME_PROPERTIES_KEYS
+
+__author__ = 'jedeko'
+
+
+@operation
+def attach_volume(ctx, **kwargs):
+    """ Create volume and attach to virtual machine.
+    """
+
+    cloud_driver = get_cloud_driver(ctx)
+
+    vm_id = ctx.target.instance.runtime_properties[CLOUDSTACK_ID_PROPERTY]
+    vm = get_vm_by_id(ctx, cloud_driver, vm_id)
+
+    volume_name = ctx.source.node.properties['name']
+    volume_size = ctx.source.node.properties['size']
+
+    volume = cloud_driver.create_volume(name=volume_name,
+                                        size=volume_size)
+
+    cloud_driver.attach_volume(node=vm,
+                               volume=volume)

--- a/cloudstack_plugin/volume.py
+++ b/cloudstack_plugin/volume.py
@@ -53,6 +53,10 @@ def attach_volume(ctx, **kwargs):
     cloud_driver.attach_volume(node=vm,
                                volume=volume)
 
+    ctx.source.instance.runtime_properties[CLOUDSTACK_ID_PROPERTY] = volume.id
+    ctx.source.instance.runtime_properties[CLOUDSTACK_TYPE_PROPERTY] = \
+        VOLUME_CLOUDSTACK_TYPE
+    
 
 @operation
 def detach_volume(ctx, **kwargs):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -154,6 +154,8 @@ node_types:
                     default: ''
                 size:
                     default: ''
+                expunge:
+                    default: false
                 use_external_resource:
                     default: false
                 resource_id:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -147,6 +147,20 @@ node_types:
             cloudstack_config:
                 default: {}
 
+    cloudify.cloudstack.nodes.Volume:
+            derived_from: cloudify.nodes.Volume
+            properties:
+                name:
+                    default: ''
+                size:
+                    default: ''
+                use_external_resource:
+                    default: false
+                resource_id:
+                    default: ''
+                cloudstack_config:
+                    default: {}
+
     cloudify.cloudstack.nodes.KeyPair:
         derived_from: cloudify.nodes.Root
         properties:
@@ -206,6 +220,17 @@ relationships:
 #             cloudify.interfaces.relationship_lifecycle:
 #                 - establish: cloudstack.neutron_plugin.router.connect_subnet
 #                 - unlink: cloudstack.neutron_plugin.router.disconnect_subnet
+
+    cloudify.cloudstack.volume_contained_in_vm:
+            derived_from: cloudify.relationships.contained_in
+            source_interfaces:
+                cloudify.interfaces.relationship_lifecycle:
+                    establish:
+                        implementation: cloudstack.cloudstack_plugin.volume.attach_volume
+                        inputs: {}
+                    unlink:
+                        implementation: cloudstack.cloudstack_plugin.volume.detach_volume
+                        inputs: {}
 
     cloudify.cloudstack.virtual_machine_connected_to_floating_ip:
         derived_from: cloudify.relationships.connected_to

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,13 +7,12 @@ plugins:
         executor: central_deployment_agent
         source: https://github.com/cloudify-cosmo/cloudify-cloudstack-plugin/archive/1.2m5.zip
 
-
 node_types:
     cloudify.cloudstack.nodes.VirtualMachine:
         derived_from: cloudify.nodes.Compute
         properties:
             server: {}
-            portmaps: 
+            portmaps:
                 default: {}
             network:
                 default: {}
@@ -27,7 +26,7 @@ node_types:
                 default: {}
         interfaces:
             cloudify.interfaces.lifecycle:
-                create: 
+                create:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.create
                     inputs: {}
                 start:
@@ -36,11 +35,11 @@ node_types:
                 stop:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.stop
                     inputs: {}
-                delete: 
+                delete:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.delete
                     inputs: {}
             cloudify.interfaces.host:
-                get_state: 
+                get_state:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.get_state
                     inputs: {}
 
@@ -59,7 +58,7 @@ node_types:
                 uninstall:
                     implementation: windows_agent_installer.windows_agent_installer.tasks.uninstall
                     inputs: {}
-                restart: 
+                restart:
                     implementation: windows_agent_installer.windows_agent_installer.tasks.restart
                     inputs: {}
             cloudify.interfaces.plugin_installer:
@@ -70,9 +69,9 @@ node_types:
     cloudify.cloudstack.nodes.Network:
         derived_from: cloudify.nodes.Subnet
         properties:
-            network: 
+            network:
                 default: {}
-            firewall: 
+            firewall:
                 default: {}
             use_external_resource:
                 default: false
@@ -150,18 +149,17 @@ node_types:
     cloudify.cloudstack.nodes.Volume:
             derived_from: cloudify.nodes.Volume
             properties:
-                name:
-                    default: ''
-                size:
-                    default: ''
-                expunge:
-                    default: false
+                volume: {}
                 use_external_resource:
                     default: false
                 resource_id:
                     default: ''
                 cloudstack_config:
                     default: {}
+            interfaces:
+                cloudify.interfaces.lifecycle:
+                    create: cloudstack.cloudstack_plugin.volume.create
+                    delete: cloudstack.cloudstack_plugin.volume.delete
 
     cloudify.cloudstack.nodes.KeyPair:
         derived_from: cloudify.nodes.Root
@@ -223,25 +221,21 @@ relationships:
 #                 - establish: cloudstack.neutron_plugin.router.connect_subnet
 #                 - unlink: cloudstack.neutron_plugin.router.disconnect_subnet
 
-    cloudify.cloudstack.volume_contained_in_vm:
-            derived_from: cloudify.relationships.contained_in
+    cloudify.cloudstack.volume_connected_to_vm:
+            derived_from: cloudify.relationships.connected_to
             source_interfaces:
                 cloudify.interfaces.relationship_lifecycle:
-                    establish:
-                        implementation: cloudstack.cloudstack_plugin.volume.attach_volume
-                        inputs: {}
-                    unlink:
-                        implementation: cloudstack.cloudstack_plugin.volume.detach_volume
-                        inputs: {}
+                    establish: cloudstack.cloudstack_plugin.virtual_machine.attach_volume
+                    unlink: cloudstack.cloudstack_plugin.virtual_machine.detach_volume
 
     cloudify.cloudstack.virtual_machine_connected_to_floating_ip:
         derived_from: cloudify.relationships.connected_to
         source_interfaces:
             cloudify.interfaces.relationship_lifecycle:
-                establish: 
+                establish:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.connect_floating_ip
                     inputs: {}
-                unlink: 
+                unlink:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.disconnect_floating_ip
                     inputs: {}
 
@@ -249,7 +243,7 @@ relationships:
         derived_from: cloudify.relationships.connected_to
         source_interfaces:
             cloudify.interfaces.relationship_lifecycle:
-                establish: 
+                establish:
                     implementation: cloudstack.cloudstack_plugin.floatingip.connect_network
                     inputs: {}
                 unlink:
@@ -260,7 +254,7 @@ relationships:
         derived_from: cloudify.relationships.connected_to
         source_interfaces:
             cloudify.interfaces.relationship_lifecycle:
-                establish: 
+                establish:
                     implementation: cloudstack.cloudstack_plugin.floatingip.connect_vpc
                     inputs: {}
                 unlink:
@@ -278,10 +272,10 @@ relationships:
         derived_from: cloudify.relationships.connected_to
         source_interfaces:
             cloudify.interfaces.relationship_lifecycle:
-                establish: 
+                establish:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.connect_network
                     inputs: {}
-                unlink: 
+                unlink:
                     implementation: cloudstack.cloudstack_plugin.virtual_machine.disconnect_network
                     inputs: {}
 


### PR DESCRIPTION
The following feature for the Cloudstack plugin enables the possibility to have multiple disks on a virtual machine. From the blueprint add a sperate volume_node and attach it with a contained_in relationship. Rollback is configured to default, detach the volume from the vm and destroy the disk if the purge attribute is set to true in the blueprint. 