### PR TITLE
1.2.1 build

### DIFF
--- a/cloudstack_plugin/network.py
+++ b/cloudstack_plugin/network.py
@@ -104,8 +104,15 @@ def create(ctx, **kwargs):
                     acl_type = acl.get('type')
 
                     for port in acl_ports:
+                        # Specifying port ranges "start_port:end_port"
+                        ports = str(port).split(':')
+                        start_port = int(ports[0])
+                        if len(ports) == 1:
+                            end_port = start_port
+                        elif len(ports) == 2:
+                            end_port = int(ports[1])
                         create_acl(cloud_driver, acl_protocol, acl_list.id,
-                                   acl_cidr, port, port, acl_type)
+                                   acl_cidr, start_port, end_port, acl_type)
 
         else:
             ctx.logger.info('Creating network: {0}'.format(network_name))

--- a/cloudstack_plugin/network.py
+++ b/cloudstack_plugin/network.py
@@ -111,6 +111,11 @@ def create(ctx, **kwargs):
                             end_port = start_port
                         elif len(ports) == 2:
                             end_port = int(ports[1])
+                        else:
+                            raise NonRecoverableError(
+                                'Port may be a single port or a port range '
+                                'in the format start_port:end_port.'
+                                'Entered: {0}'.format(port))
                         create_acl(cloud_driver, acl_protocol, acl_list.id,
                                    acl_cidr, start_port, end_port, acl_type)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
     cloudstack:
         executor: central_deployment_agent
-        source: https://github.com/icclab/cloudify-cloudstack-plugin/archive/1.2.1-build.zip
+        source: https://github.com/cloudify-cosmo/cloudify-cloudstack-plugin/archive/1.2.1.zip
 
 node_types:
     cloudify.cloudstack.nodes.VirtualMachine:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
     cloudstack:
         executor: central_deployment_agent
-        source: https://github.com/cloudify-cosmo/cloudify-cloudstack-plugin/archive/1.2.1.zip
+        source: https://github.com/icclab/cloudify-cloudstack-plugin/archive/1.2.1-build.zip
 
 node_types:
     cloudify.cloudstack.nodes.VirtualMachine:


### PR DESCRIPTION
Added support for port range specification in network firewall. Port ranges can be specified as a string value with `:` delimiter between start and end port (e.g. '15000:15100').

Following example allows INGRESS for ports TCP 22 and TCP 15000-15100 (both inclusive).

```
node_templates:
  network:
    type: cloudify.cloudstack.nodes.Network
    properties:
      firewall:
        - type: ingress
          protocol: TCP
          cidr: 0.0.0.0/0
          ports: [22, '15000:15100']
```
